### PR TITLE
Fix search and poster retrieval

### DIFF
--- a/telegram_bridge/README.md
+++ b/telegram_bridge/README.md
@@ -1,0 +1,14 @@
+# Telegram Kodi Bridge
+
+This folder contains a small FastAPI bridge (`bridge.py`) and Kodi addon scripts for streaming videos from Telegram chats.
+
+## Components
+- **bridge.py** – exposes HTTP endpoints using Telethon to communicate with Telegram.
+- **default.py** – Kodi front‑end script that lists movies/series and calls the bridge.
+- **telegram_fetcher.py** – handles syncing chats and storing metadata in SQLite.
+- **db_async_split.py** – lightweight read helpers for the SQLite databases.
+- **settings.xml** – Kodi settings including API credentials and folder IDs.
+
+## Logging
+The bridge writes verbose debug output to `debug.log` in the same directory. Kodi's log records each request made by `telegram_fetcher`.
+

--- a/telegram_bridge/bridge.py
+++ b/telegram_bridge/bridge.py
@@ -1,0 +1,248 @@
+# -*- coding: utf-8 -*-
+"""
+FastAPI-Bridge zwischen Kodi-Addon und Telegram (Telethon)
+"""
+
+from __future__ import annotations
+import asyncio, glob, io, json, os, time, logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from fastapi import Body, FastAPI, HTTPException, Query, Response, Request
+from fastapi.responses import StreamingResponse
+from telethon import TelegramClient, functions
+from telethon.errors import FolderIdInvalidError
+from telethon.tl.types import MessageMediaDocument
+
+SESSION   = os.getenv("TELEGRAM_SESSION", "kodi")
+TEMP_DIR  = Path(os.getenv("KODI_TEMP_DIR", Path.home() / ".kodi" / "temp"))
+TEMP_DIR.mkdir(parents=True, exist_ok=True)
+
+LOG_FILE = Path(__file__).with_name("debug.log")
+logging.basicConfig(
+    filename=LOG_FILE,
+    level=logging.DEBUG,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger("bridge")
+
+tg_client: Optional[TelegramClient] = None
+tg_connected = False
+client_lock  = asyncio.Lock()
+
+app = FastAPI()
+
+@app.middleware("http")
+async def log_http(request: Request, call_next):
+    body = await request.body()
+    logger.debug(f"--> {request.method} {request.url.path}?{request.url.query} {body.decode(errors='ignore')}")
+    response = await call_next(request)
+    try:
+        resp_body = b""
+        async for chunk in response.body_iterator:
+            resp_body += chunk
+        response = Response(content=resp_body, status_code=response.status_code,
+                            headers=dict(response.headers), media_type=response.media_type)
+        logger.debug(f"<-- {response.status_code} {resp_body[:500].decode(errors='ignore')}")
+    except Exception as e:
+        logger.debug(f"Logging response failed: {e}")
+    return response
+
+# --------------------------------------------------------------------------- #
+#  Hilfen
+# --------------------------------------------------------------------------- #
+def require_client():
+    if not tg_client or not tg_connected:
+        raise HTTPException(503, "Bridge nicht initialisiert – /set_api_creds")
+
+async def ensure_client():
+    if tg_client and tg_connected:
+        return
+    raise HTTPException(503, "Noch nicht verbunden → /set_api_creds")
+
+# --------------------------------------------------------------------------- #
+#  Login / API-Creds
+# --------------------------------------------------------------------------- #
+@app.post("/set_api_creds")
+async def set_api_creds(data: Dict[str, str] = Body(...)):
+    global tg_client, tg_connected
+    api_id, api_hash = int(data["api_id"]), data["api_hash"]
+    phone = data.get("phone") or None
+    if tg_client:
+        try: await tg_client.disconnect()
+        except Exception: pass
+    tg_client = TelegramClient(SESSION, api_id, api_hash)
+    await tg_client.start(phone=phone)
+    tg_connected = True
+    return {"status":"connected"}
+
+@app.get("/is_ready")
+def is_ready(): return {"connected": tg_connected}
+
+# --------------------------------------------------------------------------- #
+#  Chat-Liste
+# --------------------------------------------------------------------------- #
+async def _collect_chats(folder_ids: Optional[str]):
+    """Liefert Chats, optional gefiltert nach einer oder mehreren Folder-IDs."""
+    require_client()
+    chats: List[Dict[str, str]] = []
+    async with client_lock:
+        try:
+            if folder_ids:
+                ids = [int(f) for f in str(folder_ids).split(",") if f]
+                for fid in ids:
+                    try:
+                        async for d in tg_client.iter_dialogs(folder=fid, limit=None):
+                            t = "channel" if d.is_channel else "group" if d.is_group else "user"
+                            chats.append({"chat_id": d.id, "title": d.name, "type": t})
+                    except FolderIdInvalidError:
+                        continue
+            else:
+                async for d in tg_client.iter_dialogs(limit=None):
+                    t = "channel" if d.is_channel else "group" if d.is_group else "user"
+                    chats.append({"chat_id": d.id, "title": d.name, "type": t})
+        except FolderIdInvalidError:
+            pass
+    return chats
+
+@app.post("/sync")
+async def sync_post(folder: Optional[str] = Query(None)):
+    return {"chats": await _collect_chats(folder)}
+
+@app.get("/sync")
+async def sync_get(folder: Optional[str] = Query(None)):
+    return {"chats": await _collect_chats(folder)}
+
+# --------------------------------------------------------------------------- #
+#  Folders (Dialog Filters)
+# --------------------------------------------------------------------------- #
+@app.get("/folders")
+async def get_folders():
+    """Liefert vorhandene Telegram-Ordner (Dialog Filters)."""
+    require_client()
+    async with client_lock:
+        result = await tg_client(functions.messages.GetDialogFiltersRequest())
+        dialog_filters = []
+        if result and hasattr(result, "filters"):
+            try:
+                dialog_filters = list(result.filters or [])
+            except TypeError:
+                dialog_filters = []
+    return {
+        "folders": [
+            {
+                "id": f.id,
+                "title": str(getattr(f.title, "text", str(f.title))).replace("\n", " ").strip(),
+            }
+            for f in dialog_filters
+        ]
+    }
+
+# --------------------------------------------------------------------------- #
+#  Raw-History & Suche
+# --------------------------------------------------------------------------- #
+def _msg_to_dict(m):
+    if m.photo:
+        tp,sz,mt,dur,cap,txt="photo",None,"",None,"",""
+    elif isinstance(m.media, MessageMediaDocument):
+        tp="video"; sz=m.media.document.size; mt=m.media.document.mime_type
+        dur=next((a.seconds for a in m.media.document.attributes if hasattr(a,"seconds")),None)
+        cap,txt=m.message,""
+    else:
+        tp,sz,mt,dur,cap,txt="text",None,"",None,"",m.text or ""
+    return {"id":m.id,"date":str(m.date),"type":tp,"file_size":sz,"mime_type":mt,
+            "duration":dur,"caption":cap,"text":txt}
+
+@app.post("/history_raw")
+async def history_raw(payload: Dict[str,int]=Body(...)):
+    require_client(); cid=payload["chat_id"]; limit=int(payload.get("limit",500))
+    async with client_lock:
+        msgs=await tg_client.get_messages(cid, limit=limit)
+    return [_msg_to_dict(m) for m in msgs]
+
+@app.post("/search")
+async def search(payload: Dict=Body(...)):
+    """Volltextsuche in einem Chat."""
+    require_client()
+    cid=payload["chat_id"]; query=payload["query"]; limit=int(payload.get("limit",50))
+    async with client_lock:
+        msgs=await tg_client.get_messages(cid, limit=limit, search=query)
+    return [_msg_to_dict(m) for m in msgs]
+
+# --------------------------------------------------------------------------- #
+#  Logo & Poster
+# --------------------------------------------------------------------------- #
+@app.get("/logo/{chat_id}")
+async def logo(chat_id:int):
+    require_client()
+    async with client_lock:
+        chat=await tg_client.get_entity(chat_id)
+        if not chat.photo: raise HTTPException(404)
+        data=await tg_client.download_profile_photo(chat, file=bytes)
+    return StreamingResponse(io.BytesIO(data), media_type="image/jpeg")
+
+@app.get("/poster/{chat_id}/{msg_id}")
+async def poster(chat_id:int, msg_id:int):
+    """Poster oder Videothumb zu einer Nachricht"""
+    require_client()
+    async with client_lock:
+        msg = await tg_client.get_messages(chat_id, ids=msg_id)
+        data = None
+        if msg.photo:
+            data = await tg_client.download_media(msg.photo, file=bytes)
+        elif isinstance(msg.media, MessageMediaDocument) and msg.media.document.thumbs:
+            data = await tg_client.download_media(msg.media.document, file=bytes, thumb=-1)
+        if not data:
+            raise HTTPException(404)
+    return StreamingResponse(io.BytesIO(data), media_type="image/jpeg")
+
+# --------------------------------------------------------------------------- #
+#  Stream-Download
+# --------------------------------------------------------------------------- #
+ACTIVE,CANCEL={},{}
+async def _tg_to_file(chat_id:int,msg_id:int,fp:Path):
+    require_client(); key=(chat_id,msg_id); CANCEL[key]=asyncio.Event()
+    async with client_lock: msg=await tg_client.get_messages(chat_id, ids=msg_id)
+    def prog(cur,total):
+        if CANCEL[key].is_set(): raise asyncio.CancelledError()
+    await tg_client.download_media(msg.media, file=str(fp),
+                                   progress_callback=prog, seek=fp.stat().st_size if fp.exists() else 0)
+    CANCEL.pop(key,None)
+
+def _next_file()->Path:
+    nums=[int(Path(f).stem) for f in glob.glob(str(TEMP_DIR/"*.mp4")) if Path(f).stem.isdigit()]
+    return TEMP_DIR/f"{max(nums+[-1])+1:03d}.mp4"
+
+async def _wait_header(fp:Path,t=60):
+    for _ in range(t):
+        if fp.exists() and fp.stat().st_size>1_000_000: return True
+        await asyncio.sleep(1)
+    return False
+
+@app.get("/get_strm/{chat_id}/{msg_id}")
+async def get_strm(chat_id:int,msg_id:int):
+    require_client()
+    fp=_next_file(); key=(chat_id,msg_id)
+    if key not in ACTIVE or ACTIVE[key].done():
+        ACTIVE[key]=asyncio.create_task(_tg_to_file(chat_id,msg_id,fp))
+    if not await _wait_header(fp):
+        raise HTTPException(503,"Header noch nicht fertig")
+    return Response(str(fp), media_type="text/plain")
+
+# --------------------------------------------------------------------------- #
+#  Temp-Dateien
+# --------------------------------------------------------------------------- #
+@app.get("/list_temp_files")
+def list_temp(): return {"files":[{"file":f,"size":os.path.getsize(f)} for f in glob.glob(str(TEMP_DIR/"*.mp4"))]}
+
+@app.post("/delete_temp_file")
+def del_temp(payload:Dict[str,str]=Body(...)):
+    fp=payload.get("file","")
+    if os.path.exists(fp): os.remove(fp)
+    return {"status":"deleted"}
+
+@app.post("/delete_all_temp_files")
+def del_all():
+    for f in glob.glob(str(TEMP_DIR/"*.mp4")): os.remove(f)
+    return {"status":"ok"}

--- a/telegram_bridge/bridge.py
+++ b/telegram_bridge/bridge.py
@@ -143,6 +143,7 @@ async def get_folders():
 #  Raw-History & Suche
 # --------------------------------------------------------------------------- #
 def _msg_to_dict(m):
+    logger.debug("[TG MSG] %s", m.stringify())
     if m.photo:
         tp,sz,mt,dur,cap,txt="photo",None,"",None,"",""
     elif isinstance(m.media, MessageMediaDocument):
@@ -159,6 +160,8 @@ async def history_raw(payload: Dict[str,int]=Body(...)):
     require_client(); cid=payload["chat_id"]; limit=int(payload.get("limit",500))
     async with client_lock:
         msgs=await tg_client.get_messages(cid, limit=limit)
+        for m in msgs:
+            logger.debug("[HISTORY_RAW] %s", m.stringify())
     return [_msg_to_dict(m) for m in msgs]
 
 @app.post("/search")
@@ -168,6 +171,8 @@ async def search(payload: Dict=Body(...)):
     cid=payload["chat_id"]; query=payload["query"]; limit=int(payload.get("limit",50))
     async with client_lock:
         msgs=await tg_client.get_messages(cid, limit=limit, search=query)
+        for m in msgs:
+            logger.debug("[SEARCH] %s", m.stringify())
     return [_msg_to_dict(m) for m in msgs]
 
 # --------------------------------------------------------------------------- #
@@ -188,6 +193,7 @@ async def poster(chat_id:int, msg_id:int):
     require_client()
     async with client_lock:
         msg = await tg_client.get_messages(chat_id, ids=msg_id)
+        logger.debug("[POSTER] %s", msg.stringify())
         data = None
         if msg.photo:
             data = await tg_client.download_media(msg.photo, file=bytes)
@@ -203,7 +209,9 @@ async def poster(chat_id:int, msg_id:int):
 ACTIVE,CANCEL={},{}
 async def _tg_to_file(chat_id:int,msg_id:int,fp:Path):
     require_client(); key=(chat_id,msg_id); CANCEL[key]=asyncio.Event()
-    async with client_lock: msg=await tg_client.get_messages(chat_id, ids=msg_id)
+    async with client_lock:
+        msg=await tg_client.get_messages(chat_id, ids=msg_id)
+        logger.debug("[STREAM] %s", msg.stringify())
     def prog(cur,total):
         if CANCEL[key].is_set(): raise asyncio.CancelledError()
     await tg_client.download_media(msg.media, file=str(fp),

--- a/telegram_bridge/db_async_split.py
+++ b/telegram_bridge/db_async_split.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""
+Lesender DB-Layer für Filme/Serien
+"""
+
+from __future__ import annotations
+import os, sqlite3
+from pathlib import Path
+from typing import Any, Dict, List
+
+import xbmcaddon, xbmcvfs, xbmc
+
+# --------------------------------------------------------------------------- #
+ADDON        = xbmcaddon.Addon()
+PROFILE_DIR  = xbmcvfs.translatePath(ADDON.getAddonInfo("profile"))
+DATA_DIR     = os.path.join(PROFILE_DIR, "data")
+os.makedirs(DATA_DIR, exist_ok=True)
+
+DB_MOVIES  = Path(os.path.join(DATA_DIR, "meta_movies.sqlite"))
+DB_SERIES  = Path(os.path.join(DATA_DIR, "meta_series.sqlite"))
+
+# --------------------------------------------------------------------------- #
+def dict_factory(cur: sqlite3.Cursor, row: tuple[Any, ...]) -> Dict[str, Any]:
+    return {col[0]: row[idx] for idx, col in enumerate(cur.description)}
+
+def _db(type_: str) -> Path:
+    return DB_MOVIES if type_ == "movie" else DB_SERIES
+
+# --------------------------------------------------------------------------- #
+def get_chats_by_type(type_: str) -> List[Dict[str, Any]]:
+    with sqlite3.connect(_db(type_)) as conn:
+        conn.row_factory = dict_factory
+        cur = conn.execute(
+            "SELECT DISTINCT chat_id, chat_title AS name FROM filme WHERE type=? ORDER BY name COLLATE NOCASE",
+            (type_,),
+        )
+        return cur.fetchall()
+
+# ---------------- Latest ----------------
+def get_latest_movies(limit: int = 20, offset: int = 0):
+    with sqlite3.connect(DB_MOVIES) as conn:
+        conn.row_factory = dict_factory
+        cur = conn.execute(
+            "SELECT * FROM filme WHERE type='movie' ORDER BY id DESC LIMIT ? OFFSET ?",
+            (limit, offset),
+        )
+        return cur.fetchall()
+
+def get_latest_movies_by_chat(chat_id: int, limit: int = 20, offset: int = 0):
+    with sqlite3.connect(DB_MOVIES) as conn:
+        conn.row_factory = dict_factory
+        cur = conn.execute(
+            "SELECT * FROM filme WHERE type='movie' AND chat_id=? ORDER BY id DESC LIMIT ? OFFSET ?",
+            (chat_id, limit, offset),
+        )
+        return cur.fetchall()
+
+def get_latest_series(limit: int = 20, offset: int = 0):
+    with sqlite3.connect(DB_SERIES) as conn:
+        conn.row_factory = dict_factory
+        cur = conn.execute(
+            """
+            SELECT * FROM filme
+            WHERE type='series'
+            GROUP BY series_id
+            ORDER BY MAX(id) DESC
+            LIMIT ? OFFSET ?
+            """,
+            (limit, offset),
+        )
+        return cur.fetchall()
+
+def get_series_for_chat(chat_id: int):
+    with sqlite3.connect(DB_SERIES) as conn:
+        conn.row_factory = dict_factory
+        cur = conn.execute(
+            "SELECT * FROM filme WHERE type='series' AND series_id=? ORDER BY id DESC LIMIT 1",
+            (chat_id,),
+        )
+        return cur.fetchall()
+
+def get_series_in_chat(chat_id: int, limit: int = 20, offset: int = 0):
+    with sqlite3.connect(DB_SERIES) as conn:
+        conn.row_factory = dict_factory
+        cur = conn.execute(
+            "SELECT * FROM filme WHERE type='series' AND series_id=? GROUP BY series_id ORDER BY MAX(id) DESC LIMIT ? OFFSET ?",
+            (chat_id, limit, offset),
+        )
+        return cur.fetchall()
+
+# ---------------- Suche ----------------
+def search_movies(term: str, limit: int = 40, offset: int = 0):
+    like = f"%{term}%"
+    with sqlite3.connect(DB_MOVIES) as conn:
+        conn.row_factory = dict_factory
+        cur = conn.execute(
+            """
+            SELECT * FROM filme
+            WHERE type='movie' AND (title LIKE ? OR plot LIKE ?)
+            ORDER BY jahr DESC
+            LIMIT ? OFFSET ?
+            """,
+            (like, like, limit, offset),
+        )
+        return cur.fetchall()
+
+def search_series(term: str, limit: int = 40, offset: int = 0):
+    like = f"%{term}%"
+    with sqlite3.connect(DB_SERIES) as conn:
+        conn.row_factory = dict_factory
+        cur = conn.execute(
+            """
+            SELECT * FROM filme
+            WHERE type='series' AND (title LIKE ? OR episodentitel LIKE ? OR plot LIKE ?)
+            ORDER BY jahr DESC
+            LIMIT ? OFFSET ?
+            """,
+            (like, like, like, limit, offset),
+        )
+        return cur.fetchall()
+
+# ---------------- Serien-Details ----------------
+def get_seasons(series_id: str):
+    with sqlite3.connect(DB_SERIES) as conn:
+        conn.row_factory = dict_factory
+        return conn.execute(
+            "SELECT DISTINCT season AS number FROM filme WHERE series_id=? ORDER BY number",
+            (series_id,),
+        ).fetchall()
+
+def get_episodes(series_id: str, season: int):
+    with sqlite3.connect(DB_SERIES) as conn:
+        conn.row_factory = dict_factory
+        return conn.execute(
+            "SELECT * FROM filme WHERE series_id=? AND season=? ORDER BY episode",
+            (series_id, season),
+        ).fetchall()

--- a/telegram_bridge/default.py
+++ b/telegram_bridge/default.py
@@ -1,0 +1,417 @@
+# -*- coding: utf-8 -*-
+"""
+Kodi-Addon-Frontend
+Reiter:  Suche · Filme · Serien
+Auto-Sync der neuesten Einträge & globale Volltextsuche
+"""
+
+from __future__ import annotations
+import json, os, sys, urllib.parse, urllib.request
+
+import xbmc, xbmcaddon, xbmcgui, xbmcplugin, xbmcvfs
+
+from resources.lib import db_async_split as db
+from resources.lib import telegram_fetcher
+
+# --------------------------------------------------------------------------- #
+#  Addon-Konstanten & Helfer
+# --------------------------------------------------------------------------- #
+ADDON        = xbmcaddon.Addon()
+BASE_URL     = sys.argv[0]
+HANDLE       = int(sys.argv[1])
+ARGS         = urllib.parse.parse_qs(sys.argv[2][1:])
+
+USE_FOLDER_FILTER = ADDON.getSettingBool("use_folder_filter")
+
+# --------------------------------------------------------------------------- #
+def get_bridge_url() -> str:
+    """Ermittelt die Bridge-URL unter Berücksichtigung Host/Port-Fallback."""
+    url = ADDON.getSetting("bridge_url").strip()
+    if url:
+        return url.rstrip("/")
+    host = ADDON.getSetting("bridge_host") or "127.0.0.1"
+    port = ADDON.getSetting("bridge_port") or "5000"
+    return f"http://{host}:{port}".rstrip("/")
+
+BRIDGE_URL = get_bridge_url()
+
+# --------------------------------------------------------------------------- #
+def add_folder(label: str, url: str, *, art=None, info=None, is_folder=True):
+    li = xbmcgui.ListItem(label)
+    if art:
+        li.setArt(art)
+    if info:
+        li.setInfo("video", info)
+    xbmcplugin.addDirectoryItem(HANDLE, url, li, is_folder)
+
+def _int_or_zero(val, factor=1):
+    try:
+        return int(val) * factor
+    except Exception:
+        return 0
+
+# --------------------------------------------------------------------------- #
+#  Root-Menü
+# --------------------------------------------------------------------------- #
+def root_menu():
+    add_folder("Suche", f"{BASE_URL}?action=search_ui")
+    add_folder("Filme", f"{BASE_URL}?action=choose_movie_source")
+    add_folder("Serien", f"{BASE_URL}?action=choose_series_source")
+    add_folder("Einstellungen", f"{BASE_URL}?action=settings_menu")
+    xbmcplugin.endOfDirectory(HANDLE)
+
+# --------------------------------------------------------------------------- #
+#  Einstellungen & Konfiguration
+# --------------------------------------------------------------------------- #
+def settings_menu():
+    dlg = xbmcgui.Dialog()
+    opts = [
+        "Telegram Login",
+        "Filme-Ordner wählen",
+        "Serien-Ordner wählen",
+    ]
+    choice = dlg.select("Einstellungen", opts)
+    if choice == 0:
+        telegram_login()
+    elif choice == 1:
+        select_folder("movies")
+    elif choice == 2:
+        select_folder("series")
+
+def telegram_login():
+    dlg = xbmcgui.Dialog()
+    api_id = dlg.input("API ID", defaultt=ADDON.getSetting("api_id"), type=xbmcgui.INPUT_NUM)
+    if not api_id:
+        return
+    api_hash = dlg.input("API Hash", defaultt=ADDON.getSetting("api_hash"), type=xbmcgui.INPUT_ALPHANUM)
+    phone = dlg.input("Telefon", defaultt=ADDON.getSetting("phone_number"), type=xbmcgui.INPUT_ALPHANUM)
+    ADDON.setSettingString("api_id", api_id)
+    ADDON.setSettingString("api_hash", api_hash)
+    ADDON.setSettingString("phone_number", phone)
+    telegram_fetcher.bridge_connect()
+
+def select_folder(which:str):
+    folders = telegram_fetcher.get_folders()
+    if not folders:
+        xbmcgui.Dialog().ok("Fehler", "Keine Ordner gefunden")
+        return
+    labels = [f["title"].replace("\n", " ").strip() for f in folders]
+    labels.insert(0, "Alle")
+    idx = xbmcgui.Dialog().select("Ordner wählen", labels)
+    if idx == -1:
+        return
+    if idx == 0:
+        ADDON.setSettingString(f"folder_{which}_id", "")
+        ADDON.setSettingString(f"folder_{which}", "")
+    else:
+        sel = folders[idx-1]
+        ADDON.setSettingString(f"folder_{which}_id", str(sel["id"]))
+        ADDON.setSettingString(f"folder_{which}", sel["title"])
+
+def choose_folders(multi: bool = False):
+    folders = telegram_fetcher.get_folders()
+    if not folders:
+        xbmcgui.Dialog().ok("Fehler", "Keine Ordner gefunden")
+        return None
+    labels = [f["title"].replace("\n", " ").strip() for f in folders]
+    if multi:
+        idxs = xbmcgui.Dialog().multiselect("Ordner wählen", labels)
+        if idxs is None:
+            return None
+        return [str(folders[i]["id"]) for i in idxs]
+    idx = xbmcgui.Dialog().select("Ordner wählen", labels)
+    if idx == -1:
+        return None
+    return str(folders[idx]["id"])
+
+def choose_chat(folder_ids=None):
+    chats = telegram_fetcher.get_user_chats(folder_ids)
+    if not chats:
+        xbmcgui.Dialog().ok("Fehler", "Keine Chats gefunden")
+        return None
+    labels = [str(c.get("title") or c.get("id")).replace("\n", " ").strip() for c in chats]
+    idx = xbmcgui.Dialog().select("Chat wählen", labels)
+    if idx == -1:
+        return None
+    return str(chats[idx]["id"])
+
+def choose_movie_source():
+    opts = ["Datenbank", "Telegram"]
+    choice = xbmcgui.Dialog().select("Filme", opts)
+    if choice == 0:
+        xbmc.executebuiltin(
+            f"Container.Update({BASE_URL}?action=list_movies_db&offset=0)"
+        )
+    elif choice == 1:
+        pick_movie_chat()
+
+def choose_series_source():
+    opts = ["Datenbank", "Telegram"]
+    choice = xbmcgui.Dialog().select("Serien", opts)
+    if choice == 0:
+        xbmc.executebuiltin(
+            f"Container.Update({BASE_URL}?action=list_series_db&offset=0)"
+        )
+    elif choice == 1:
+        pick_series_chat()
+
+def pick_movie_chat():
+    fid = None
+    if USE_FOLDER_FILTER:
+        fid = ADDON.getSetting("folder_movies_id") or None
+        if not fid:
+            fid = choose_folders()
+        if fid is None:
+            return
+    chat = choose_chat([fid] if fid else None)
+    if chat:
+        xbmc.executebuiltin(f"Container.Update({BASE_URL}?action=list_movies&chat_id={chat}&offset=0)")
+
+def pick_series_chat():
+    fid = None
+    if USE_FOLDER_FILTER:
+        fid = ADDON.getSetting("folder_series_id") or None
+        if not fid:
+            fid = choose_folders()
+        if fid is None:
+            return
+    chat = choose_chat([fid] if fid else None)
+    if chat:
+        xbmc.executebuiltin(f"Container.Update({BASE_URL}?action=list_series&chat_id={chat}&offset=0)")
+
+# --------------------------------------------------------------------------- #
+#  Globale Suche
+# --------------------------------------------------------------------------- #
+def search_ui() -> None:
+    folder_ids = None
+    if USE_FOLDER_FILTER:
+        stored = []
+        for key in ("folder_movies_id", "folder_series_id"):
+            val = ADDON.getSetting(key)
+            if val:
+                stored.append(val)
+        if stored:
+            folder_ids = stored
+        else:
+            folder_ids = choose_folders(multi=True)
+            if folder_ids is None:
+                return
+    dlg = xbmcgui.Dialog()
+    term = dlg.input("Suchbegriff eingeben …", type=xbmcgui.INPUT_ALPHANUM)
+    if not term:
+        return
+    dlg_progress = xbmcgui.DialogProgress()
+    dlg_progress.create("Suche", f"Suche nach '{term}' …")
+    telegram_fetcher.global_search_and_store(term, dlg_progress, folder_ids)
+    dlg_progress.close()
+    # Ergebnisse anzeigen
+    xbmc.executebuiltin(
+        f"Container.Update({BASE_URL}?action=list_search_results&query={urllib.parse.quote(term)}&offset=0)"
+    )
+
+def list_search_results(query: str, offset: int):
+    page_size = 40
+    movies = db.search_movies(query, limit=page_size, offset=offset)
+    series = db.search_series(query, limit=page_size, offset=offset)
+    for item in movies + series:
+        art = {
+            "thumb": item.get("poster_path") or item.get("logo_path"),
+            "icon": item.get("poster_path") or item.get("logo_path"),
+            "fanart": item.get("poster_path") or item.get("logo_path"),
+        }
+        info = {
+            "title": item.get("title") or item.get("episodentitel"),
+            "plot": item.get("plot", ""),
+            "year": _int_or_zero(item.get("jahr")),
+        }
+        url = f"{BASE_URL}?action=play&chat_id={item['chat_id']}&msg_id={item['msg_id']}"
+        add_folder(info["title"], url, art=art, info=info, is_folder=False)
+    # „Mehr laden…“
+    if len(movies) + len(series) == page_size:
+        next_offset = offset + page_size
+        add_folder(
+            "Mehr laden …",
+            f"{BASE_URL}?action=list_search_results&query={urllib.parse.quote(query)}&offset={next_offset}",
+        )
+    xbmcplugin.endOfDirectory(HANDLE)
+
+# --------------------------------------------------------------------------- #
+#  Auto-Sync & Listing Filme
+# --------------------------------------------------------------------------- #
+def list_movies_db(offset: int):
+    batch = 20
+    telegram_fetcher.auto_sync_latest("movie", batch)
+    movies = db.get_latest_movies(batch, offset)
+    for mv in movies:
+        art = {"thumb": mv.get("poster_path") or mv.get("logo_path")}
+        info = {
+            "title": mv.get("title"),
+            "plot": mv.get("plot", ""),
+            "year": _int_or_zero(mv.get("jahr")),
+            "duration": _int_or_zero(mv.get("duration"), 60),
+        }
+        url = f"{BASE_URL}?action=play&chat_id={mv['chat_id']}&msg_id={mv['msg_id']}"
+        add_folder(mv["title"], url, art=art, info=info, is_folder=False)
+    if len(movies) == batch:
+        add_folder(
+            "Mehr laden …",
+            f"{BASE_URL}?action=list_movies_db&offset={offset+batch}",
+        )
+    xbmcplugin.endOfDirectory(HANDLE)
+
+def list_latest_movies(chat_id: str, offset: int):
+    batch = 20
+    telegram_fetcher.sync_latest_chat(int(chat_id), "movie", offset + batch)
+    movies = db.get_latest_movies_by_chat(int(chat_id), batch, offset)
+    for mv in movies:
+        art = {"thumb": mv.get("poster_path") or mv.get("logo_path")}
+        info = {
+            "title": mv.get("title"),
+            "plot": mv.get("plot", ""),
+            "year": _int_or_zero(mv.get("jahr")),
+            "duration": _int_or_zero(mv.get("duration"), 60),
+        }
+        url = f"{BASE_URL}?action=play&chat_id={mv['chat_id']}&msg_id={mv['msg_id']}"
+        add_folder(mv["title"], url, art=art, info=info, is_folder=False)
+    if len(movies) == batch:
+        add_folder(
+            "Mehr laden …",
+            f"{BASE_URL}?action=list_movies&chat_id={chat_id}&offset={offset+batch}",
+        )
+    xbmcplugin.endOfDirectory(HANDLE)
+
+# --------------------------------------------------------------------------- #
+#  Auto-Sync & Listing Serien
+# --------------------------------------------------------------------------- #
+def list_series_db(offset: int):
+    batch = 20
+    telegram_fetcher.auto_sync_latest("series", batch)
+    series = db.get_latest_series(batch, offset)
+    for se in series:
+        art = {"thumb": se.get("poster_path") or se.get("logo_path")}
+        info = {
+            "plot": se.get("plot", ""),
+            "year": _int_or_zero(se.get("jahr")),
+        }
+        url = f"{BASE_URL}?action=series_detail&series_id={se['series_id']}&chat_id={se['chat_id']}"
+        add_folder(se["title"], url, art=art, info=info)
+    if len(series) == batch:
+        add_folder(
+            "Mehr laden …",
+            f"{BASE_URL}?action=list_series_db&offset={offset+batch}",
+        )
+    xbmcplugin.endOfDirectory(HANDLE)
+
+def list_latest_series(chat_id: str, offset: int):
+    batch = 20
+    telegram_fetcher.sync_latest_chat(int(chat_id), "series", offset + batch)
+    series = db.get_series_for_chat(int(chat_id))
+    for se in series:
+        art = {"thumb": se.get("poster_path") or se.get("logo_path")}
+        info = {
+            "plot": se.get("plot", ""),
+            "year": _int_or_zero(se.get("jahr")),
+        }
+        url = f"{BASE_URL}?action=series_detail&series_id={se['series_id']}&chat_id={se['chat_id']}"
+        add_folder(se["title"], url, art=art, info=info)
+    if len(series) == batch:
+        add_folder(
+            "Mehr laden …",
+            f"{BASE_URL}?action=list_series&chat_id={chat_id}&offset={offset+batch}",
+        )
+    xbmcplugin.endOfDirectory(HANDLE)
+
+# --------------------------------------------------------------------------- #
+#  Serien-Untermenüs
+# --------------------------------------------------------------------------- #
+def list_seasons(series_id: str, chat_id: str):
+    seasons = db.get_seasons(series_id)
+    for s in seasons:
+        label = f"Staffel {s['number']}"
+        url   = f"{BASE_URL}?action=list_episodes&series_id={series_id}&season={s['number']}&chat_id={chat_id}"
+        add_folder(label, url)
+    xbmcplugin.endOfDirectory(HANDLE)
+
+def list_episodes(series_id: str, season: int, chat_id: str):
+    eps = db.get_episodes(series_id, season)
+    for ep in eps:
+        title = ep.get("episodentitel") or f"S{season:02d}E{ep.get('episode'):02d}"
+        info  = {"title": title, "plot": ep.get("plot", "")}
+        art   = {"thumb": ep.get("poster_path") or ep.get("logo_path")}
+        url   = f"{BASE_URL}?action=play&chat_id={chat_id}&msg_id={ep['msg_id']}"
+        add_folder(title, url, art=art, info=info, is_folder=False)
+    xbmcplugin.endOfDirectory(HANDLE)
+
+# --------------------------------------------------------------------------- #
+#  Playback
+# --------------------------------------------------------------------------- #
+def play(chat_id: str, msg_id: str):
+    strm_url = f"{BRIDGE_URL}/get_strm/{chat_id}/{msg_id}"
+    try:
+        with urllib.request.urlopen(strm_url) as r:
+            fp = r.read().decode().strip()
+        li = xbmcgui.ListItem(path=fp); li.setProperty("is_playable", "true")
+        xbmcplugin.setResolvedUrl(HANDLE, True, li)
+    except Exception as e:
+        xbmcgui.Dialog().ok("Fehler", str(e))
+
+# --------------------------------------------------------------------------- #
+#  Router
+# --------------------------------------------------------------------------- #
+if __name__ == "__main__":
+    action = ARGS.get("action", ["root"])[0]
+
+    if action == "root":
+        root_menu()
+
+    elif action == "search_ui":
+        search_ui()
+
+    elif action == "list_search_results":
+        list_search_results(
+            ARGS["query"][0],
+            int(ARGS.get("offset", ["0"])[0]),
+        )
+
+    elif action == "pick_movie_chat":
+        pick_movie_chat()
+
+    elif action == "pick_series_chat":
+        pick_series_chat()
+
+    elif action == "choose_movie_source":
+        choose_movie_source()
+
+    elif action == "choose_series_source":
+        choose_series_source()
+
+    elif action == "list_movies_db":
+        list_movies_db(int(ARGS.get("offset", ["0"])[0]))
+
+    elif action == "list_series_db":
+        list_series_db(int(ARGS.get("offset", ["0"])[0]))
+
+    elif action == "list_movies":
+        list_latest_movies(ARGS["chat_id"][0], int(ARGS.get("offset", ["0"])[0]))
+
+    elif action == "list_series":
+        list_latest_series(ARGS["chat_id"][0], int(ARGS.get("offset", ["0"])[0]))
+
+    elif action == "series_detail":
+        list_seasons(ARGS["series_id"][0], ARGS["chat_id"][0])
+
+    elif action == "list_episodes":
+        list_episodes(
+            ARGS["series_id"][0],
+            int(ARGS["season"][0]),
+            ARGS["chat_id"][0],
+        )
+
+    elif action == "play":
+        play(ARGS["chat_id"][0], ARGS["msg_id"][0])
+
+    elif action == "settings_menu":
+        settings_menu()
+
+    else:
+        root_menu()

--- a/telegram_bridge/settings.xml
+++ b/telegram_bridge/settings.xml
@@ -1,0 +1,33 @@
+<settings>
+<!--   Telegram-Zugang   -->
+<category label="Telegram">
+<setting id="api_id" type="text" default="" option="number" label="API ID"/>
+<setting id="api_hash" type="text" default="" option="hidden" label="API Hash"/>
+<setting id="session_name" type="text" default="kodi" label="Sitzungsname"/>
+<setting id="phone_number" type="text" default="" option="hidden" label="Telefonnummer (optional)"/>
+</category>
+<!--   Bridge   -->
+<category label="Bridge">
+<setting id="bridge_host" type="text" default="127.0.0.1" label="Bridge-Host"/>
+<setting id="bridge_port" type="number" default="5000" label="Bridge-Port"/>
+<setting id="bridge_url" type="text" default="" label="Bridge-URL (überschreibt Host/Port)"/>
+<setting id="temp_dir" type="folder" default="" label="Temporäres Verzeichnis"/>
+<setting id="cleanup_days" type="number" default="3" label="Cleanup – Tage"/>
+</category>
+<!--   Chat-Filter (Platzhalter)   -->
+<category label="Chat-Filter">
+<setting id="show_channels" type="bool" default="true" label="Channels anzeigen"/>
+<setting id="show_groups" type="bool" default="true" label="Gruppen anzeigen"/>
+<setting id="show_users" type="bool" default="false" label="Private Chats anzeigen"/>
+<setting id="use_folder_filter" type="bool" default="true" label="Zuerst nach Ordnern filtern"/>
+</category>
+<!--   Sync-Optionen (Platzhalter)   -->
+<category label="Sync">
+<setting id="default_movie_limit" type="number" default="1000" label="Standard-Filmlimit"/>
+<setting id="parallel_downloads" type="number" default="8" label="Parallele Poster-Downloads"/>
+<setting id="folder_movies" type="text" default="Filme" label="Telegram-Ordner für Filme"/>
+<setting id="folder_movies_id" type="text" default="" visible="false" label="(intern) Telegram-Ordner-ID für Filme"/>
+<setting id="folder_series" type="text" default="Serien" label="Telegram-Ordner für Serien"/>
+<setting id="folder_series_id" type="text" default="" visible="false" label="(intern) Telegram-Ordner-ID für Serien"/>
+</category>
+</settings>

--- a/telegram_bridge/telegram_fetcher.py
+++ b/telegram_bridge/telegram_fetcher.py
@@ -73,6 +73,7 @@ def _speed_pragmas(conn: sqlite3.Connection):
     conn.execute("PRAGMA temp_store=MEMORY")
 
 def _open_db(path: Path) -> sqlite3.Connection:
+    xbmc.log(f"[DB] open {path}", xbmc.LOGDEBUG)
     conn = sqlite3.connect(path)
     _speed_pragmas(conn)
     conn.execute(
@@ -113,6 +114,7 @@ def _open_db(path: Path) -> sqlite3.Connection:
 def _safe_execute(conn: sqlite3.Connection, q: str, p: Tuple[Any, ...] = ()):
     for _ in range(3):
         try:
+            xbmc.log(f"[DB] exec {q} {p}", xbmc.LOGDEBUG)
             conn.execute(q, p); return
         except sqlite3.OperationalError as e:
             if "locked" in str(e):
@@ -433,6 +435,8 @@ def fetch_and_store(chat_id:int, dialog=None, sync_type:str="movie",
             if dialog and n%5==0:
                 dialog.update(int((n+1)/len(entries)*100))
             if (n+1)%BATCH_SIZE==0: conn.commit()
+        xbmc.log("[DB] commit", xbmc.LOGDEBUG)
         conn.commit()
     finally:
+        xbmc.log("[DB] close", xbmc.LOGDEBUG)
         conn.close()

--- a/telegram_bridge/telegram_fetcher.py
+++ b/telegram_bridge/telegram_fetcher.py
@@ -1,0 +1,438 @@
+# -*- coding: utf-8 -*-
+"""
+Telegram-Fetcher: Holt Filme & Serien aus Chats, extrahiert Metadaten,
+schreibt sie samt Postern in die lokale SQLite-DB.
+Neu (2025-06):  • global_search_and_store()  • auto_sync_latest()
+"""
+
+from __future__ import annotations
+import json, os, random, re, sqlite3, threading, time, traceback, unicodedata
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import xbmc, xbmcaddon, xbmcvfs
+try:
+    import xbmcgui
+except ImportError:
+    xbmcgui = None  # type: ignore
+
+# --------------------------------------------------------------------------- #
+#  Settings & Dirs
+# --------------------------------------------------------------------------- #
+ADDON         = xbmcaddon.Addon()
+PROFILE_DIR   = xbmcvfs.translatePath(ADDON.getAddonInfo("profile"))
+DATA_DIR      = os.path.join(PROFILE_DIR, "data"); os.makedirs(DATA_DIR, exist_ok=True)
+POSTER_DIR    = os.path.join(DATA_DIR, "poster"); os.makedirs(POSTER_DIR, exist_ok=True)
+
+DB_MOVIES = Path(os.path.join(DATA_DIR, "meta_movies.sqlite"))
+DB_SERIES = Path(os.path.join(DATA_DIR, "meta_series.sqlite"))
+
+def get_bridge_url() -> str:
+    url = ADDON.getSetting("bridge_url").strip()
+    if url:
+        return url.rstrip("/")
+    host = ADDON.getSetting("bridge_host") or "127.0.0.1"
+    port = ADDON.getSetting("bridge_port") or "5000"
+    return f"http://{host}:{port}".rstrip("/")
+
+BRIDGE_URL    = get_bridge_url()
+
+BATCH_SIZE    = 50
+MAX_RETRIES   = 3
+RETRY_SLEEP   = 2.0
+
+# --------------------------------------------------------------------------- #
+#  Bridge Connection Helpers
+# --------------------------------------------------------------------------- #
+def _bridge_ready() -> bool:
+    resp = _json_request(f"{BRIDGE_URL}/is_ready")
+    return bool(isinstance(resp, dict) and resp.get("connected"))
+
+def bridge_connect() -> bool:
+    api_id = ADDON.getSetting("api_id")
+    api_hash = ADDON.getSetting("api_hash")
+    phone = ADDON.getSetting("phone_number")
+    if not api_id or not api_hash:
+        return False
+    data = {"api_id": api_id, "api_hash": api_hash}
+    if phone:
+        data["phone"] = phone
+    resp = _json_request(f"{BRIDGE_URL}/set_api_creds", method="POST", data=data)
+    return bool(isinstance(resp, dict) and resp.get("status") == "connected")
+
+def ensure_bridge() -> bool:
+    return _bridge_ready() or bridge_connect()
+
+# --------------------------------------------------------------------------- #
+#  DB-Helpers
+# --------------------------------------------------------------------------- #
+def _speed_pragmas(conn: sqlite3.Connection):
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=OFF")
+    conn.execute("PRAGMA cache_size=100000")
+    conn.execute("PRAGMA temp_store=MEMORY")
+
+def _open_db(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    _speed_pragmas(conn)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS filme (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id         INTEGER,
+            chat_title      TEXT,
+            msg_id          INTEGER,
+            title           TEXT,
+            plot            TEXT,
+            jahr            INTEGER,
+            episodentitel   TEXT,
+            poster_path     TEXT,
+            logo_path       TEXT,
+            file_unique_id  TEXT,
+            file_size       INTEGER,
+            duration        INTEGER,
+            mime_type       TEXT,
+            rating          TEXT,
+            genres          TEXT,
+            land            TEXT,
+            fsk             TEXT,
+            regie           TEXT,
+            tmdb_rating     TEXT,
+            collection      TEXT,
+            status          TEXT DEFAULT 'pending',
+            type            TEXT,
+            series_id       INTEGER,
+            season          INTEGER,
+            episode         INTEGER
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+def _safe_execute(conn: sqlite3.Connection, q: str, p: Tuple[Any, ...] = ()):
+    for _ in range(3):
+        try:
+            conn.execute(q, p); return
+        except sqlite3.OperationalError as e:
+            if "locked" in str(e):
+                time.sleep(1)
+            else:
+                raise
+
+def _db_path(sync_type: str) -> Path:
+    return DB_MOVIES if sync_type == "movie" else DB_SERIES
+
+# --------------------------------------------------------------------------- #
+#  Bridge-Request
+# --------------------------------------------------------------------------- #
+import urllib.parse, urllib.request
+
+def _json_request(url: str, *, method="GET", params=None, data=None, timeout=30):
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    xbmc.log(f"[FETCHER] {method} {url} data={data}", xbmc.LOGDEBUG)
+    req = urllib.request.Request(url, method=method)
+    if method == "POST":
+        req.add_header("Content-Type", "application/json")
+        if data is not None:
+            req.data = json.dumps(data).encode() if not isinstance(data, bytes) else data
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            txt = r.read().decode()
+            xbmc.log(f"[FETCHER] -> {txt[:200]}", xbmc.LOGDEBUG)
+            return json.loads(txt)
+    except Exception as e:
+        xbmc.log(f"[BRIDGE ERROR] {url}: {e}", xbmc.LOGERROR)
+        return {}
+
+# --------------------------------------------------------------------------- #
+#  Bridge-Wrapper-API
+# --------------------------------------------------------------------------- #
+def get_user_chats(folder_ids: List[str] | None = None) -> List[Dict[str, Any]]:
+    """Liest die verfügbaren Chats, optional gefiltert nach Folder-IDs."""
+    chats: List[Dict[str, Any]] = []
+    ids = folder_ids or [None]
+    for fid in ids:
+        params = {"folder": fid} if fid else None
+        resp = _json_request(f"{BRIDGE_URL}/sync", method="POST", params=params)
+        chs = resp.get("chats", []) if isinstance(resp, dict) else []
+        for c in chs:
+            c.setdefault("id", c.get("chat_id"))
+            if "title" in c and isinstance(c["title"], str):
+                c["title"] = c["title"].replace("\n", " ").strip()
+            chats.append(c)
+    return chats
+
+def get_folders() -> List[Dict[str, Any]]:
+    resp = _json_request(f"{BRIDGE_URL}/folders")
+    folders = resp.get("folders", []) if isinstance(resp, dict) else resp
+    for f in folders:
+        if "title" in f and isinstance(f["title"], str):
+            f["title"] = f["title"].replace("\n", " ").strip()
+    return folders
+
+def download_logo(chat_id: int) -> str:
+    url = f"{BRIDGE_URL}/logo/{chat_id}"
+    fp  = os.path.join(POSTER_DIR, f"logo_{chat_id}.jpg")
+    if os.path.exists(fp) and os.path.getsize(fp) > 10_000:
+        return fp
+    try:
+        with urllib.request.urlopen(url, timeout=20) as r, open(fp, "wb") as out:
+            out.write(r.read())
+        return fp
+    except Exception:
+        return ""
+
+def download_poster(chat_id: int, photo_id: int) -> str:
+    url = f"{BRIDGE_URL}/poster/{chat_id}/{photo_id}"
+    fp  = os.path.join(POSTER_DIR, f"poster_{chat_id}_{photo_id}.jpg")
+    if os.path.exists(fp) and os.path.getsize(fp) > 10_000:
+        return fp
+    try:
+        with urllib.request.urlopen(url, timeout=20) as r, open(fp, "wb") as out:
+            out.write(r.read())
+        return fp
+    except Exception:
+        return ""
+
+# --------------------------------------------------------------------------- #
+#  Parser-Regex
+# --------------------------------------------------------------------------- #
+FILM_REGEX = re.compile(r"^(?:[^\w]*Titel[:\s]+)?\s*(.*?)\s*(?:[-–]|:)\s*(19|20)\d{2}", re.I|re.S)
+YEAR_REGEX = re.compile(r"(19|20)\d{2}")
+RATING_REGEX  = re.compile(r"Rating[:\s]+([0-9]\.?[0-9]*)")
+PLOT_REGEX    = re.compile(r"Plot:\s*(.*?)(?:Rating[:\s]+[0-9]\.?[0-9]*|#|$)", re.S)
+GENRE_REGEX   = re.compile(r"#([A-Za-zÄÖÜäöüß]+)")
+LENGTH_REGEX  = re.compile(r"Länge[:\s]+([0-9]+)\s*Minuten")
+COUNTRY_REGEX = re.compile(r"Produktionsland[:\s]+([^\n]+)")
+FSK_REGEX     = re.compile(r"FSK[:\s]+([0-9]+)")
+REGIE_REGEX   = re.compile(r"Regie[:\s]+([^\n]+)")
+TMDB_REGEX    = re.compile(r"TMDbRating[:\s]+([0-9]\.?[0-9]*)")
+COLLECTION_REGEX = re.compile(r"Filmreihe[:\s]+([^\n]+)")
+
+def _duration(d):
+    if not d: return 0
+    if isinstance(d, int): return d//60 if d>3000 else d
+    if isinstance(d, str):
+        if ":" in d:
+            h,m = map(int,d.split(":",1)); return h*60+m
+        if d.isdigit(): return int(d)
+    return 0
+
+def _clean_title(txt: str)->str:
+    txt = unicodedata.normalize("NFKC", txt or "")
+    txt = re.sub(r"\s*\(?((19|20)\d{2})\)?\s*$","",txt)
+    txt = re.sub(r"\s*\([A-Z]{2,}\)$","",txt)
+    return txt.strip(" -–:")
+
+def extract_metadata(text: str)->Dict[str,str]:
+    text = unicodedata.normalize("NFKC", text or "")
+    meta={}
+    m = FILM_REGEX.search(text)
+    if m:
+        meta["title"]=_clean_title(m.group(1)); meta["year"]=m.group(2)
+    else:
+        first=_clean_title(text.splitlines()[0]); meta["title"]=first
+        y = YEAR_REGEX.search(first) or YEAR_REGEX.search(text)
+        meta["year"]=y.group(0) if y else ""
+    meta["plot"]=text.strip()
+    meta["rating"]=(RATING_REGEX.search(text) or [None,""])[1]
+    meta["genres"]=GENRE_REGEX.findall(text)
+    meta["duration"]=(LENGTH_REGEX.search(text) or [None,""])[1]
+    meta["country"]=(COUNTRY_REGEX.search(text) or [None,""])[1].strip()
+    meta["fsk"]=(FSK_REGEX.search(text) or [None,""])[1]
+    meta["director"]=(REGIE_REGEX.search(text) or [None,""])[1].strip()
+    meta["tmdb_rating"]=(TMDB_REGEX.search(text) or [None,""])[1]
+    meta["collection"]=(COLLECTION_REGEX.search(text) or [None,""])[1].strip()
+    return meta
+
+def parse_film_block(msgs: List[Dict[str,Any]], chat_id:int)->List[Dict[str,Any]]:
+    """Erkennt Filmblöcke in einer Nachrichtenliste."""
+    films: List[Dict[str, Any]] = []
+    for i, v in enumerate(msgs):
+        if v.get("type") != "video":
+            continue
+        # Metadaten aus Caption oder benachbarter Textnachricht
+        meta_txt = v.get("caption") or ""
+        if not meta_txt:
+            if i+1 < len(msgs) and msgs[i+1].get("type") == "text":
+                meta_txt = msgs[i+1].get("text", "")
+            elif i > 0 and msgs[i-1].get("type") == "text":
+                meta_txt = msgs[i-1].get("text", "")
+        meta = extract_metadata(meta_txt)
+
+        # Poster: bevorzugt benachbarte Photo-Nachricht, sonst Videothumb
+        poster_id = None
+        if i+1 < len(msgs) and msgs[i+1].get("type") == "photo":
+            poster_id = msgs[i+1]["id"]
+        elif i > 0 and msgs[i-1].get("type") == "photo":
+            poster_id = msgs[i-1]["id"]
+        else:
+            poster_id = v["id"]
+
+        films.append({
+            "msg_id": v["id"],
+            "poster_id": poster_id,
+            "title": meta["title"],
+            "jahr": meta["year"],
+            "plot": meta["plot"],
+            "rating": meta["rating"],
+            "genres": meta["genres"],
+            "duration": v.get("duration") or _duration(meta["duration"]),
+            "land": meta["country"],
+            "fsk": meta["fsk"],
+            "regie": meta["director"],
+            "tmdb_rating": meta["tmdb_rating"],
+            "collection": meta["collection"],
+            "file_size": v.get("file_size"),
+            "mime_type": v.get("mime_type"),
+        })
+    return films
+
+def extract_series(text:str):
+    m=re.search(r"[sS](\d{1,2})\s*[eE](\d{1,2})\s*[-:\s]+(.+)",text or "")
+    if m:return int(m.group(1)),int(m.group(2)),m.group(3).strip()
+    m=re.search(r"[eE](\d{1,2})\s*[-:\s]+(.+)",text or "")
+    if m:return None,int(m.group(1)),m.group(2).strip()
+    return None,None,text.strip() if text else ""
+
+def first_year(*txts):
+    for t in txts:
+        y=YEAR_REGEX.search(t or "")
+        if y:return y.group(0)
+    return ""
+
+# --------------------------------------------------------------------------- #
+#  GLOBAL SUCHEN
+# --------------------------------------------------------------------------- #
+def global_search_and_store(term: str, dialog=None, folder_ids: List[str] | None = None,
+                            limit_per_chat: int = 50):
+    """Suche in ausgewählten Chats/Folders und speichere Treffer in die DB."""
+    if not ensure_bridge():
+        return
+    chs = get_user_chats(folder_ids)
+    total = len(chs)
+    term_lc = term.lower()
+    for idx, ch in enumerate(chs):
+        if dialog:
+            dialog.update(int(idx / max(1, total) * 100), f"{idx+1}/{total} {ch['title']}")
+        msgs = _json_request(f"{BRIDGE_URL}/history_raw", method="POST",
+                             data={"chat_id": ch["id"], "limit": limit_per_chat})
+        if not msgs:
+            continue
+        is_series = term_lc in (ch.get("title") or "").lower()
+        if is_series:
+            fetch_and_store(ch["id"], dialog=None, sync_type="series",
+                             limit_override=None, raw_messages=msgs)
+            continue
+        films = parse_film_block(msgs, ch["id"])
+        allowed = [f["msg_id"] for f in films if term_lc in (f["title"] + " " + f["plot"]).lower()]
+        if allowed:
+            fetch_and_store(ch["id"], dialog=None, sync_type="movie",
+                             limit_override=None, raw_messages=msgs, allowed_msg_ids=allowed)
+
+# --------------------------------------------------------------------------- #
+#  AUTO-SYNC LATEST
+# --------------------------------------------------------------------------- #
+def auto_sync_latest(sync_type: str, per_chat: int = 20, folder_ids: List[str] | None = None):
+    if not ensure_bridge():
+        return
+    for ch in get_user_chats(folder_ids):
+        msgs=_json_request(f"{BRIDGE_URL}/history_raw", method="POST",
+                           data={"chat_id":ch["id"], "limit":per_chat})
+        if msgs:
+            fetch_and_store(ch["id"], dialog=None, sync_type=sync_type,
+                            limit_override=None, raw_messages=msgs)
+
+def sync_latest_chat(chat_id: int, sync_type: str, limit: int = 20):
+    """Sync die neuesten Nachrichten eines einzelnen Chats."""
+    if not ensure_bridge():
+        return
+    msgs = _json_request(f"{BRIDGE_URL}/history_raw", method="POST",
+                         data={"chat_id": chat_id, "limit": limit})
+    if msgs:
+        fetch_and_store(chat_id, dialog=None, sync_type=sync_type,
+                        limit_override=None, raw_messages=msgs)
+
+# --------------------------------------------------------------------------- #
+#  Kernfunktion fetch_and_store
+# --------------------------------------------------------------------------- #
+def fetch_and_store(chat_id:int, dialog=None, sync_type:str="movie",
+                    limit_override:int|None=None, raw_messages:List[Dict]|None=None,
+                    allowed_msg_ids: List[int] | None = None):
+    xbmc.log(f"[FETCHER] {sync_type} Sync Chat {chat_id}", xbmc.LOGINFO)
+    dbp=_db_path(sync_type); conn=_open_db(dbp)
+    try:
+        # 0) Messages holen
+        if raw_messages is None:
+            limit = limit_override if limit_override is not None else 1000
+            raw_messages=_json_request(f"{BRIDGE_URL}/history_raw", method="POST",
+                                       data={"chat_id":chat_id,"limit":limit})
+        if not raw_messages: return
+
+        # 1) Chat-Metadaten
+        chat_meta=next((c for c in get_user_chats() if c["id"]==chat_id), {})
+        chat_title=chat_meta.get("title") or chat_meta.get("first_name")\
+                    or chat_meta.get("username") or str(chat_id)
+        logo=download_logo(chat_id)
+
+        # 2) Einträge builden
+        entries=[]
+        if sync_type=="movie":
+            films=parse_film_block(raw_messages, chat_id)
+            if allowed_msg_ids:
+                films=[f for f in films if f["msg_id"] in allowed_msg_ids]
+            for f in films:
+                poster=download_poster(chat_id,f["poster_id"]) if f["poster_id"] else ""
+                entries.append({
+                    "id":f["msg_id"], "chat_title":chat_title, "title":f["title"],
+                    "plot":f["plot"], "jahr":f["jahr"], "episodentitel":"",
+                    "poster_path":poster, "logo_path":logo,
+                    "file_size":f["file_size"], "duration":f["duration"], "mime":f["mime_type"],
+                    "rating":f["rating"], "genres":",".join(f["genres"]), "land":f["land"],
+                    "fsk":f["fsk"], "regie":f["regie"], "tmdb_rating":f["tmdb_rating"],
+                    "collection":f["collection"], "type":"movie",
+                    "series_id":None, "season":None, "episode":None
+                })
+        else:  # series
+            series_plot=next((m.get("text") for m in raw_messages if m.get("type")=="text" and m.get("text")), "")
+            series_year=first_year(series_plot)
+            for m in raw_messages:
+                if m.get("type")!="video": continue
+                season,episode,title=extract_series(m.get("caption") or "")
+                if allowed_msg_ids and m["id"] not in allowed_msg_ids:
+                    continue
+                entries.append({
+                    "id":m["id"], "chat_title":chat_title, "title":chat_title,
+                    "plot":series_plot, "jahr":series_year, "episodentitel":title,
+                    "poster_path":logo, "logo_path":logo,
+                    "file_size":m.get("file_size"), "duration":m.get("duration"),
+                    "mime":m.get("mime_type"), "rating":"", "genres":"", "land":"",
+                    "fsk":"", "regie":"", "tmdb_rating":"", "collection":"",
+                    "type":"series", "series_id":chat_id, "season":season, "episode":episode
+                })
+
+        # 3) Write
+        for n,e in enumerate(entries):
+            _safe_execute(conn, "INSERT OR IGNORE INTO filme (chat_id,msg_id) VALUES (?,?)",
+                          (chat_id,e["id"]))
+            _safe_execute(conn, """
+            UPDATE filme SET
+              chat_title=?, title=?, plot=?, jahr=?, episodentitel=?,
+              poster_path=COALESCE(?,poster_path), logo_path=?,
+              file_size=?, duration=?, mime_type=?, rating=?, genres=?,
+              land=?, fsk=?, regie=?, tmdb_rating=?, collection=?,
+              status='pending', type=?, series_id=?, season=?, episode=?
+            WHERE chat_id=? AND msg_id=?
+            """, (e["chat_title"],e["title"],e["plot"],e["jahr"],e["episodentitel"],
+                  e["poster_path"],e["logo_path"],e["file_size"],e["duration"],e["mime"],
+                  e["rating"],e["genres"],e["land"],e["fsk"],e["regie"],e["tmdb_rating"],
+                  e["collection"],e["type"],e["series_id"],e["season"],e["episode"],
+                  chat_id,e["id"]))
+            if dialog and n%5==0:
+                dialog.update(int((n+1)/len(entries)*100))
+            if (n+1)%BATCH_SIZE==0: conn.commit()
+        conn.commit()
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- improve poster endpoint to support video thumbnails
- parse movie metadata more flexibly when scanning chats
- filter search results locally and store only matches

## Testing
- `python3 -m py_compile telegram_bridge/*.py`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fd1ec4f508322b99c23ecfba98464